### PR TITLE
Update updateVersion.sh to deal with nuget versioning

### DIFF
--- a/omi.version
+++ b/omi.version
@@ -8,5 +8,6 @@ OMI_BUILDVERSION_PATCH=0
 OMI_BUILDVERSION_BUILDNR=11
 OMI_BUILDVERSION_DATE=20170208
 OMI_BUILDVERSION_STATUS=Developer_Build
+OMI_BUILDVERSION_NUGET=1.2.100001
 
 #-------------------------------- End of File -----------------------------------

--- a/updateVersion.sh
+++ b/updateVersion.sh
@@ -88,6 +88,30 @@ if [ $P_INCREMENT -ne 0 ]; then
         echo "Updated version number, Was: $VERSION_OLD, Now $VERSION_NEW"
         echo "Updated release date,   Was: $DATE_OLD, Now $DATE_NEW"
     fi
+
+    # Since build number is incremented, update the nuget version as well
+    # Nuget version is formatting: major.minor.1<2-digit-patch><3-digit-build>
+    #
+    # For this, it's easier just to load the version file ...
+
+    . $VERSION_FILE
+
+    if [ -z "$OMI_BUILDVERSION_MAJOR" \
+         -o -z "$OMI_BUILDVERSION_MINOR" \
+         -o -z "$OMI_BUILDVERSION_PATCH" \
+         -o -z "$OMI_BUILDVERSION_BUILDNR" ]; then
+        echo "Must specify -f qualifier (version file)" 1>& 2
+        exit 1
+    fi
+
+    NUGET_VERSION=`printf "%d.%d.1%02d%03d" $OMI_BUILDVERSION_MAJOR $OMI_BUILDVERSION_MINOR $OMI_BUILDVERSION_PATCH $OMI_BUILDVERSION_BUILDNR`
+
+    perl -i -pe "s/(^[A-Z]*_BUILDVERSION_NUGET)=.*/\1=$NUGET_VERSION/" $VERSION_FILE
+
+    if [ $VERBOSE -ne 0 ]; then
+        echo "Updated nuget version,  Was: $OMI_BUILDVERSION_NUGET, Now $NUGET_VERSION"
+    fi
+
 fi
 
 # Set release build

--- a/updateVersion.sh
+++ b/updateVersion.sh
@@ -100,7 +100,19 @@ if [ $P_INCREMENT -ne 0 ]; then
          -o -z "$OMI_BUILDVERSION_MINOR" \
          -o -z "$OMI_BUILDVERSION_PATCH" \
          -o -z "$OMI_BUILDVERSION_BUILDNR" ]; then
-        echo "Must specify -f qualifier (version file)" 1>& 2
+        echo "Unale to recognize OMI versioning after sourcing version file" 1>& 2
+        exit 1
+    fi
+
+    # Sanity test that the patch number is short enough for nuget encoding
+    if [ ${#OMI_BUILDVERSION_PATCH} -gt 2 ]; then
+        echo "\$OMI_BUILDVERSION_PATCH is too long for nuget encoding"
+        exit 1
+    fi
+
+    # Verify that the new build number isn't too long for nuget encoding
+    if [ ${#VERSION_NEW} -gt 3 ]; then
+        echo "New build version number is too long for nuget encoding"
         exit 1
     fi
 


### PR DESCRIPTION
Nuget version looks like this:
  Sample Linux Version: 1.2.42-12
  Sample Nuget Version: 1.2.142012

The nuget patch number is encoded as follows:
  1<2-digit-patch><3-digit-build-number>

**Note: I'm aware that I'm checking in with the wrong nuget version. This will be fixed automatically on the next nightly build, but might allow us to more easily generate a new nuget package automatically.**

@Microsoft/omi-devs @Microsoft/ostc-devs 
